### PR TITLE
投稿機能における非同期通信の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,9 +223,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -267,7 +264,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,66 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+       `<div class="main-chat__list__message">
+          <div class="main-chat__list__message__upper">
+            <div class="main-chat__list__message__upper__user-name">
+              ${message.user_name}
+            </div>
+            <div class="main-chat__list__message__upper__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="main-chat__list__message__lower">
+            <p class="main-chat__list__message__lower__content">
+              ${message.content}
+            </p>
+          </div>
+          <img src=${message.image} >
+        </div>`
+      return html;
+    } else {
+      var html =
+       `<div class="main-chat__list__message">
+          <div class="main-chat__list__message__upper">
+            <div class="main-chat__list__message__upper__user-name">
+              ${message.user_name}
+            </div>
+            <div class="main-chat__list__message__upper__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="main-chat__list__message__lower">
+            <p class="main-chat__list__message__lower__content">
+              ${message.content}
+            </p>
+          </div>
+        </div>`
+      return html;
+    };
+  }
+  
+  $('#new_message').on('submit', function(e){
+    e.preventDefault()
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url:  url,
+      type: 'POST',  
+      data: formData,  
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.main-chat__list').append(html);
+      $('.main-chat__list').animate({ scrollTop: $('.main-chat__list')[0].scrollHeight});
+      $('form')[0].reset();
+      $('.submit-btn').prop('disabled', false);
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+  });
+  });
+});

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -122,7 +122,8 @@
     height: calc(100% - 190px);
     width: 100%;
     padding-left: 40px;
-  
+    overflow: scroll;
+
     &__message {
       padding: 35px 0 46px 0;
 
@@ -176,7 +177,6 @@
           }
 
           &__image {
-            // width: auto;
             top: 10px;
             right: 10px;
             position: absolute;
@@ -192,7 +192,6 @@
           width: 100px;
           height: 50px;
           padding: 0 30px;
-          // margin-top: 10px;
           margin-left: 15px;
           cursor: pointer;
         }

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -36,8 +36,6 @@
       &__icons {
         width: 60px;
         height: 100%;
-        // display: flex;
-        // display: block;
         text-align: right;
         
     

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,12 +10,16 @@ class MessagesController < ApplicationController
 
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'
       render :index
     end
+
+    
   end
 
   private

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -46,5 +46,5 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # 縦横を800px以内にリサイズする
-  process resize_to_fit: [800, 800]
+  process resize_to_fit: [100, 100]
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,6 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -6,7 +6,6 @@
       .main-chat__group-info__current-group__name
         = @group.name
       .main-chat__group-info__current-group__member
-        -# Menmber:
         - @group.group_users.each do |group_user|
           = group_user.user.name
     =link_to "Edit", edit_group_path(@group), class:'btn'
@@ -17,17 +16,9 @@
   .main-chat__message-form
     = form_for [@group, @message] do |f|
       .input-box
-        = f.text_field :content, class: 'input-box__text', placeholder: 'type a message'
+        = f.text_field :content, class: 'input-box__text', placeholder: 'type a message', action: group_messages_path
         = f.label :image, class: 'input-box__image' do
           = icon('fa', 'image', class: 'icon')
           = f.file_field :image, class: 'input-box__image__file'
-      = f.submit 'Send', class: 'submit-btn'
-
-    -# %form.main-chat__message-form__new-message
-    -#   .input-box
-    -#     %input{type:"text", class:"input-box__text", placeholder:"type a message"}
-    -#     %label{class: "input-box__image"}
-    -#       = icon('fas', 'image')
-    -#       %input{type: "file", class: "input-box__image__file"}
-      -# %input{type:"submit", class:"submit-btn"}
+      = f.submit 'Send', class: 'submit-btn', id: 'new_message'
 

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -16,11 +16,3 @@
             = group.name
           .side-bar__group-list__group__message
             = group.show_last_message
-
-    -# 以下はグループ一覧を作成時にコメントアウトしたもの
-    -# .side-bar__group-list__group 
-    -#   .side-bar__group-list__group__name
-    -#     -# techcamp
-      
-    -#   .side-bar__group-list__group__message
-    -#     まだメッセージがありません

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
# What
メッセージの送信機能に非同期通信を実装。
メッセージの送信を非同期で行えるようにする。

# Why
シンプルなメッセージ画面を実装するため。
メッセージを送信するたびに送信画面にリダイレクトしているため、
ビューが毎回再描画されてしまう。
これをリロードされずにメッセージを送信できるようにするため。

# Gyazogif

-テキストのみ
[![Screenshot from Gyazo](https://gyazo.com/ecd02d00e4ad85dbe387f8104d98bc9a/raw)](https://gyazo.com/ecd02d00e4ad85dbe387f8104d98bc9a)

-画像のみ
[![Screenshot from Gyazo](https://gyazo.com/d2ce03edcdb6b359fef13ec9785d9d76/raw)](https://gyazo.com/d2ce03edcdb6b359fef13ec9785d9d76)

-テキストと画像
[![Screenshot from Gyazo](https://gyazo.com/a6632d14a825b30a88e1082ceb289d93/raw)](https://gyazo.com/a6632d14a825b30a88e1082ceb289d93)

-連続投稿
[![Screenshot from Gyazo](https://gyazo.com/77986608495c3f95dfb37bf9cb9e88e2/raw)](https://gyazo.com/77986608495c3f95dfb37bf9cb9e88e2)

-アラート表示
[![Screenshot from Gyazo](https://gyazo.com/4d5e4f5872797b0b6aba9202c8ca2662/raw)](https://gyazo.com/4d5e4f5872797b0b6aba9202c8ca2662)